### PR TITLE
feat(*)!: improve the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,66 @@ TODO: Write a description here
 
 ## Usage
 
-```crystal
+To get started, require the `socket_io` library in your Crystal code:
+
+```cr
 require "socket_io"
-socket = SocketIO::Client.new(host: hostname, path: "/socketio", namespace: "/")
-socket.connect
-
-socket.on_data do |packet|
-  # packet.type
-  # packet.namespace
-  # packet.id
-  # packet.data -> JSON data object
-end
-
-socket.send("data")
-socket.send("{}")
-socket.send(data: "data", id: 123, type: :ack)
 ```
 
-TODO: Write usage instructions here
+Next, create a new Socket.IO client and connect it to the server:
+
+```cr
+socket = SocketIO::Client.new(host: "<your-hostname>")
+socket.connect
+```
+
+You can emit events to the server using the `emit` method:
+
+```cr
+socket.emit("hello", "world")
+```
+
+Additionally, you can emit events and expect an acknowledgement from the server:
+
+```cr
+data = socket.emit_with_ack("hello", "world")
+```
+
+To customize the acknowledgement timeout, you can add the timeout argument:
+
+```cr
+data = socket.emit_with_ack("hello", "world", timeout: 60.seconds)
+```
+
+To handle incoming events, use the `on` method as follows:
+
+```cr
+socket.on("news") do |event|
+  puts event.data
+end
+```
+
+To acknowledge an event, simply use the ack method as shown below:
+
+```cr
+socket.on("request") do |event|
+  event.ack("response")
+end
+```
+
+To remove event listeners, utilize one of the existing methods:
+
+```cr
+# Remove a specific listener
+socket.off("my-event", &my_listener)
+
+# Remove all event listeners for a specific event
+socket.off("my-event")
+
+# Remove all event listeners for all events
+socket.off_all()
+
+```
 
 ## Development
 

--- a/src/engine_io/engine_io.cr
+++ b/src/engine_io/engine_io.cr
@@ -40,7 +40,8 @@ module EngineIO
         loop do
           select
           when packet = @incoming.receive?
-            block.call(packet) if packet
+            break unless packet
+            block.call(packet)
           end
         end
       end

--- a/src/engine_io/engine_io.cr
+++ b/src/engine_io/engine_io.cr
@@ -35,9 +35,14 @@ module EngineIO
       send_packet(Packet.new(type: PacketType::MESSAGE, data: message))
     end
 
-    def on_message
-      loop do
-        yield @incoming.receive
+    def on_packet(&block : String | Bytes -> _)
+      spawn do
+        loop do
+          select
+          when packet = @incoming.receive?
+            block.call(packet) if packet
+          end
+        end
       end
     end
 
@@ -51,10 +56,11 @@ module EngineIO
     end
 
     def close
+      @incoming.close
       send_packet(Packet.new(type: PacketType::CLOSE))
     end
 
-    def run
+    private def run
       @websocket.on_binary do |message|
         handle_packet(message)
       end
@@ -64,7 +70,7 @@ module EngineIO
       end
     end
 
-    def handle_packet(message : String | Bytes)
+    private def handle_packet(message : String | Bytes)
       packet = @decoder.decode(message)
       Log.debug { "Received message #{packet}" }
       case packet.type
@@ -83,15 +89,12 @@ module EngineIO
 
     private def handle_open_packet(packet : Packet)
       packet_data = packet.data
-      unless packet_data.is_a?(String)
-        Log.debug { "Parse error. Invalid payload: #{packet_data}" }
-      else
-        json = JSON.parse(packet_data)
-        @ping_interval = json["pingInterval"].as_i
-        @ping_timeout = json["pingTimeout"].as_i
-        @max_payload = json["maxPayload"].as_i64
-        @connected.set(1)
-      end
+      raise "Invalid payload" unless packet_data.is_a?(String)
+      json = JSON.parse(packet_data)
+      @ping_interval = json["pingInterval"].as_i
+      @ping_timeout = json["pingTimeout"].as_i
+      @max_payload = json["maxPayload"].as_i64
+      @connected.set(1)
     end
 
     private def handle_close_packet(packet : Packet)
@@ -104,12 +107,8 @@ module EngineIO
     end
 
     private def handle_message_packet(packet : Packet)
-      packet_data = packet.data
-      if packet_data.nil?
-        Log.debug { "Parse error. Invalid payload: #{packet_data}" }
-      else
-        @incoming.send(packet_data)
-      end
+      raise "Invalid payload" unless packet_data = packet.data
+      @incoming.send(packet_data)
     end
 
     private def send_packet(packet : Packet)

--- a/src/socket_io.cr
+++ b/src/socket_io.cr
@@ -1,1 +1,4 @@
-require "./socket_io/**"
+require "./socket_io/socket_io"
+require "./socket_io/packet"
+require "./socket_io/decoder"
+require "./socket_io/decoders/**"

--- a/src/socket_io/correlation_id.cr
+++ b/src/socket_io/correlation_id.cr
@@ -1,0 +1,14 @@
+module SocketIO
+  class CorrelationID
+    @@next_number : Int64 = 1
+    @@mutex = Mutex.new
+
+    def self.next_number : Int64
+      @@mutex.lock
+      number = @@next_number
+      @@next_number += 1
+      @@mutex.unlock
+      number
+    end
+  end
+end

--- a/src/socket_io/decoder.cr
+++ b/src/socket_io/decoder.cr
@@ -1,3 +1,5 @@
+require "./packet"
+
 module SocketIO
   abstract class Decoder
     abstract def encode(packet : Packet) : String | Bytes

--- a/src/socket_io/decoders/base_decoder.cr
+++ b/src/socket_io/decoders/base_decoder.cr
@@ -1,8 +1,9 @@
-require "./packet"
-require "./decoder"
+require "../packet"
+require "../decoder"
 require "msgpack"
+require "json"
 
-module SocketIO
+module SocketIO::Decoders
   class BaseDecoder < Decoder
     def encode(packet : Packet) : Bytes | String
       # TODO: handle binary attachments if we have them
@@ -31,26 +32,26 @@ module SocketIO
 
       # TODO: look up attachments if type binary
       nsp = if message[i + 1] == '/'
-        start = i + 1
-        unless i = message.index(/[,]/, start)
-          i = message.size
-        end
-        message[start..i - 1]
-      else
-        "/"
-      end
+              start = i + 1
+              unless i = message.index(/[,]/, start)
+                i = message.size
+              end
+              message[start..i - 1]
+            else
+              "/"
+            end
 
       next_char = message[i + 1]
-      id = if next_char && next_char.to_i64?
-        start = i + 1
-        unless i = message.index(/[^0-9]/, start)
-          i = message.size
-        end
-        message[start..i - 1].to_i64
-      else
-        i += 1
-        nil
-      end
+      id = if next_char && next_char.to_u64?
+             start = i + 1
+             unless i = message.index(/[^0-9]/, start)
+               i = message.size
+             end
+             message[start..i - 1].to_u64
+           else
+             i += 1
+             nil
+           end
 
       data = parse_payload(message[i..]) if message[i]
 

--- a/src/socket_io/decoders/msgpack_decoder.cr
+++ b/src/socket_io/decoders/msgpack_decoder.cr
@@ -1,10 +1,10 @@
-require "./packet"
-require "./decoder"
-require "./json_parser"
-require "./msgpack_parser"
+require "../packet"
+require "../decoder"
+require "../json_parser"
+require "../msgpack_parser"
 require "msgpack"
 
-module SocketIO
+module SocketIO::Decoders
   class MsgpackDecoder < Decoder
     @msgpack_parser : MsgpackParser
     @json_parser : JsonParser
@@ -16,10 +16,11 @@ module SocketIO
 
     def encode(packet : Packet) : Bytes | String
       {
-        type: packet.type.value,
-        nsp:  packet.nsp,
-        data: @msgpack_parser.parse(packet.data),
-      }.to_msgpack
+        "type" => packet.type.value,
+        "nsp"  => packet.nsp,
+        "id"   => packet.id,
+        "data" => @msgpack_parser.parse(packet.data),
+      }.compact!.to_msgpack
     end
 
     def decode(message : String | Bytes) : Packet
@@ -28,7 +29,7 @@ module SocketIO
         type: PacketType.new(decoded_packet["type"].as(UInt8)),
         nsp: decoded_packet["nsp"].as(String),
         data: JSON::Any.new(@json_parser.parse(decoded_packet["data"])),
-        id: decoded_packet["id"]?.as(Int64 | Nil)
+        id: decoded_packet["id"]?.as?(Int::Primitive | Nil).try &.to_u64
       )
     end
   end

--- a/src/socket_io/emitter.cr
+++ b/src/socket_io/emitter.cr
@@ -1,0 +1,51 @@
+require "./event"
+require "json"
+
+module SocketIO
+  alias EventHandler = Event ->
+
+  class Emitter
+    @listeners : Hash(String, Array(EventHandler)) = Hash(String, Array(EventHandler)).new
+    @mutex : Mutex = Mutex.new
+
+    def on(event : String, &block : EventHandler)
+      @mutex.synchronize do
+        @listeners[event] ||= [] of EventHandler
+        @listeners[event] << block
+      end
+    end
+
+    def off(event : String, &block : EventHandler)
+      @mutex.synchronize do
+        return unless @listeners[event]?
+        @listeners[event].delete(block)
+      end
+    end
+
+    def off(event : String)
+      @mutex.synchronize { @listeners.delete(event) }
+    end
+
+    def off_all
+      @mutex.synchronize { @listeners.clear }
+    end
+
+    def emit(event : String)
+      emit(event)
+    end
+
+    def emit(event_name : String, event : Event)
+      listeners = @mutex.synchronize do
+        @listeners[event_name]?.dup
+      end
+
+      return unless listeners
+
+      listeners.each do |listener|
+        spawn do
+          listener.call(event)
+        end
+      end
+    end
+  end
+end

--- a/src/socket_io/event.cr
+++ b/src/socket_io/event.cr
@@ -1,0 +1,18 @@
+module SocketIO
+  class Event
+    getter id : UInt64?
+    getter data : Array(JSON::Any)?
+
+    @client : Client
+    @acknowledged = Atomic::Flag.new
+
+    def initialize(@client : Client, @id : UInt64? = nil, @data : Array(JSON::Any)? = nil)
+    end
+
+    def ack(*data)
+      id = @id
+      return unless id
+      @client.ack(*data, id: id) if @acknowledged.test_and_set
+    end
+  end
+end

--- a/src/socket_io/json_parser.cr
+++ b/src/socket_io/json_parser.cr
@@ -3,13 +3,13 @@ require "json"
 
 module SocketIO
   class JsonParser < Parser
-    macro add_methods_to_cast_unint_and_int(*types)
-      {% for type in types %}
-        def parse(value : {{type.id}})
-          value.to_i64
-        end
-      {% end %}
-    end
+    private macro add_methods_to_cast_unint_and_int(*types)
+    {% for type in types %}
+      def parse(value : {{type.id}})
+        value.to_i64
+      end
+    {% end %}
+  end
 
     def parse(x : Tuple)
       parse(x.to_a)

--- a/src/socket_io/msgpack_parser.cr
+++ b/src/socket_io/msgpack_parser.cr
@@ -5,23 +5,23 @@ module SocketIO
   class MsgpackParser < Parser
     def parse(x : JSON::Any)
       value = case x
-      when .as_h?
-        x.as_h
-      when .as_a?
-        x.as_a
-      when .as_s?
-        x.as_s
-      when .as_f?
-        x.as_f
-      when .as_i?
-        x.as_i
-      when .as_i64?
-        x.as_i64
-      when .as_bool?
-        x.as_bool
-      else
-        nil
-      end
+              when .as_h?
+                x.as_h
+              when .as_a?
+                x.as_a
+              when .as_s?
+                x.as_s
+              when .as_f?
+                x.as_f
+              when .as_i?
+                x.as_i
+              when .as_i64?
+                x.as_i64
+              when .as_bool?
+                x.as_bool
+              else
+                nil
+              end
       parse(value)
     end
 
@@ -30,9 +30,9 @@ module SocketIO
     end
 
     def parse(x : Hash)
-      h = {} of String => MessagePack::Type
+      h = {} of MessagePack::Type => MessagePack::Type
       x.each_with_object(h) do |(k, v), h|
-        h[k.as(String)] = parse(v).as(MessagePack::Type)
+        h[k.as(MessagePack::Type)] = parse(v).as(MessagePack::Type)
       end
       h
     end

--- a/src/socket_io/packet.cr
+++ b/src/socket_io/packet.cr
@@ -12,10 +12,10 @@ module SocketIO
   struct Packet
     getter type : PacketType
     getter nsp : String?
-    getter id : Int64?
+    getter id : UInt64?
     getter data : JSON::Any?
 
-    def initialize(@type : PacketType, @nsp : String? = nil, @data : JSON::Any? = nil, @id : Int64? = nil)
+    def initialize(@type : PacketType, @nsp : String? = nil, @data : JSON::Any? = nil, @id : UInt64? = nil)
     end
   end
 end

--- a/src/socket_io/socket_io.cr
+++ b/src/socket_io/socket_io.cr
@@ -1,8 +1,11 @@
 require "../engine_io"
+require "./decoders/base_decoder"
 require "./decoder"
-require "./base_decoder"
 require "./packet"
 require "./json_parser"
+require "./event"
+require "./emitter"
+require "./correlation_id"
 
 module SocketIO
   VERSION = "5"
@@ -18,12 +21,19 @@ module SocketIO
     @namespace : String
     @decoder : Decoder
     @parser : JsonParser = JsonParser.new
+    @emitter : Emitter = Emitter.new
+    @acks : Hash(UInt64, Channel(Packet)) = Hash(UInt64, Channel(Packet)).new
+    @acks_mutex = Mutex.new
 
-    def initialize(host : String, path : String = "/socket.io/", @namespace : String = "/", base64 : Bool = false, @decoder : Decoder = BaseDecoder.new)
+    def initialize(host : String, path : String = "/socket.io/", @namespace : String = "/", base64 : Bool = false, @decoder : Decoder = Decoders::BaseDecoder.new)
       @engine_io = EngineIO::Client.new(host: host, path: path, base64: base64)
+
       spawn do
         @engine_io.connect
       end
+
+      on_packet
+
       # Wait up to 30 seconds for engine to connect
       30.times do
         break if @engine_io.connected?
@@ -36,48 +46,126 @@ module SocketIO
       end
     end
 
-    def send(data, type : PacketType = PacketType::EVENT, id : Int64? = nil)
-      case type
-      when PacketType::EVENT, PacketType::ACK, PacketType::BINARY_EVENT, PacketType::BINARY_ACK
-        data = [data] unless data.is_a?(Array)
-      end
-      emit(type, data, id)
+    def on(event_name : String, &block : EventHandler)
+      @emitter.on(event_name, &block)
     end
 
-    def emit(event : PacketType, data = nil?, id : Int64? = nil)
-      packet = Packet.new(
-        type: event,
-        nsp: @namespace,
-        data: JSON::Any.new(@parser.parse(data)),
-        id: id
-      )
-      msg = @decoder.encode(packet)
-      @engine_io.send(msg)
+    def off(event_name : String, &block : EventHandler)
+      @emitter.off(event_name, &block)
     end
 
-    def connect(data = nil?)
-      emit(PacketType::CONNECT, data)
+    def off(event_name : String)
+      @emitter.off(event_name)
+    end
+
+    def emit(event_name : String, *data)
+      emit_event(event_name, *data)
+    end
+
+    # TODO: should we consider replacing the Event class and
+    #   this public method with a simpler callback approach?
+    #
+    # ```diff
+    # -socket.on("request") do |event|
+    # +socket.on("request") do |data, callback|
+    #   # ...
+    # -  event.ack({
+    # +  callback.call({
+    #     # ...
+    #   })
+    # end
+    # ```
+    def ack(*data, id : UInt64)
+      packet = create_packet(PacketType::ACK, data, id)
+      send_packet(packet)
+    end
+
+    def emit_with_ack(event_name : String, *data, timeout : Time::Span = 30.seconds)
+      id = CorrelationID.next_number
+      ack_channel = @acks_mutex.synchronize { @acks[id] = Channel(Packet).new(1) }
+      emit_event(event_name, *data, id: id)
+      receive_ack_or_raise_timeout(ack_channel, timeout)
+    ensure
+      @acks_mutex.synchronize { @acks.delete(id) }
+    end
+
+    def connect(data = Hash(String, String).new)
+      packet = create_packet(PacketType::CONNECT, data)
+      send_packet(packet)
     end
 
     def disconnect
-      emit(PacketType::DISCONNECT)
+      @emitter.off_all
+      @acks_mutex.synchronize do
+        @acks.each_value(&.close)
+        @acks.clear
+      end
+      packet = create_packet(PacketType::DISCONNECT, nil)
+      send_packet(packet)
     end
 
     def close
       disconnect
     end
 
-    def on_data
-      @engine_io.on_message do |data|
-        message = @decoder.decode(data)
-        Log.debug { "Received #{message.type} packet with namespace #{message.nsp} and data #{message.data}" }
-        case message.type
+    private def emit_event(*data, id : UInt64? = nil)
+      packet = create_packet(PacketType::EVENT, data, id)
+      send_packet(packet)
+    end
+
+    private def create_packet(type : PacketType, data, id : UInt64? = nil)
+      Packet.new(
+        id: id,
+        type: type,
+        nsp: @namespace,
+        data: JSON::Any.new(@parser.parse(data)),
+      )
+    end
+
+    private def send_packet(packet : Packet)
+      msg = @decoder.encode(packet)
+      @engine_io.send(msg)
+    end
+
+    private def receive_ack_or_raise_timeout(channel : Channel(Packet), timeout : Time::Span)
+      select
+      when packet = channel.receive?
+        raise "Invalid ack packet" unless packet
+        extract_event_data(packet)
+      when timeout(timeout)
+        raise "Timeout while waiting for a message."
+      end
+    end
+
+    private def on_packet
+      @engine_io.on_packet do |data|
+        packet = @decoder.decode(data)
+        Log.debug { "Received #{packet.type} packet with namespace #{packet.nsp} and data #{packet.data}" }
+        case packet.type
         when PacketType::EVENT, PacketType::ACK, PacketType::BINARY_EVENT, PacketType::BINARY_ACK
-          yield message
+          handle_event_message(packet)
         when PacketType::DISCONNECT
           close
         end
       end
+    end
+
+    private def handle_event_message(packet : Packet)
+      ack_channel = @acks_mutex.synchronize { @acks[packet.id]? if packet.id }
+
+      if ack_channel
+        ack_channel.send(packet)
+      else
+        event_name, *args = extract_event_data(packet)
+        # TODO: preserve the offset for delivery guarantees
+        event = Event.new(id: packet.id, data: args, client: self)
+        @emitter.emit(event_name.as_s, event)
+      end
+    end
+
+    private def extract_event_data(message)
+      raise "Invalid payload" unless payload = message.data
+      payload.as_a
     end
   end
 end


### PR DESCRIPTION
BREAKING CHANGES: 

- The way events are emitted to sockets has changed. The `Client#send` no longer supported, you should now use the `Client#emit` method:
  ```diff
  -socket.send("data")
  +socket.emit("data")
  ```
- Handling incoming events has changed. Instead of using `Client#on_data`, you should now use the `Client#on` method with event-specific callbacks to handle incoming events.

  ```diff
  -socket.on_data do |packet|
  -  data = packet.data
  -  case data.as_a[0].as_s
  -  when "news"
  -     puts event.data
  -  end
  -end
  +socket.on("news") do |event|
  +  puts event.data
  +end
  ```
- In the new API, acknowledging an event is done differently. Instead of using `Client::send`, you should now use the `ack` method directly on the instance of `Event`. Here's how you can modify your code:

  ```diff
  -socket.on_data do |packet|
  -  data = packet.data
  -  case data.as_a[0].as_s
  -  when "request"
  -     if id = packet.id
  -       socket.send(data: "response", id: id, type: :ack)
  -     end
  -  end
  -end
  +socket.on("request") do |event|
  +  event.ack("response")
  +end
  ```
- In the new API, built-in decoders are moved under the `SocketIO::Decoders` namespace:

  ```diff
  -socket = SocketIO::Client.new(host: "<your-host>", decoder: SocketIO::MsgpackDecoder.new)
  +socket = SocketIO::Client.new(host: "<your-host>", decoder: SocketIO::Decoders::MsgpackDecoder.new)
  ```